### PR TITLE
Fixes bug that prevents closing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -242,7 +242,7 @@ const Popover = createClass({
   },
   componentDidMount () {
     this.targetEl = findDOMNode(this)
-    if (this.props.isOpen) this.enter()
+    if (this.props.isOpen) this.open()
   },
   componentWillReceiveProps (propsNext) {
     //log(`Component received props!`, propsNext)


### PR DESCRIPTION
If isOpen is initially true, toggle never gets set true, preventing popover from ever closing. This fixes it. Tested locally!
